### PR TITLE
feature/#21 카카오 로그인 테스트

### DIFF
--- a/member_service/src/main/java/com/luckytree/member_service/member/adapter/data/KakaoTokenResponse.java
+++ b/member_service/src/main/java/com/luckytree/member_service/member/adapter/data/KakaoTokenResponse.java
@@ -11,7 +11,6 @@ public class KakaoTokenResponse {
 
     private String tokenType;
     private String accessToken;
-    private String idToken;
     private String expiresIn;
     private String refreshToken;
     private String refreshTokenExpiresIn;

--- a/member_service/src/main/java/com/luckytree/member_service/member/application/service/AuthenticationService.java
+++ b/member_service/src/main/java/com/luckytree/member_service/member/application/service/AuthenticationService.java
@@ -46,7 +46,7 @@ public class AuthenticationService implements AuthenticationUseCase {
     @Override
     public TokenDto login(String code) {
         KakaoTokenResponse kakaoTokenResponse = kakaoTokenFeignClient.getToken(new KakaoTokenRequest(code, clientId, clientSecret, redirectUri).toString());
-        log.info("카카오 토큰 요청 성공");
+        log.info("카카오 토큰 요청 성공 :: {}", kakaoTokenResponse.getAccessToken());
         KakaoUserInfo kakaoUserInfo = kakaoUserInfoFeignClient.getUser(kakaoTokenResponse.getAccessToken());
         log.info("카카오 유저 리소스 요청 성공");
         String email = kakaoUserInfo.getKakaoAccount().getEmail();


### PR DESCRIPTION
# 작업내용
* 카카오 로그인 임시로그에 토큰값 출력
* 로그인 응답객체의 필드 수정