### PR TITLE
feature/#95 [리프레시 토큰 쿠키 설정 해결]

### DIFF
--- a/member_service/src/main/java/com/luckytree/member_service/common/jwt/TokenProvider.java
+++ b/member_service/src/main/java/com/luckytree/member_service/common/jwt/TokenProvider.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Date;
 import java.util.Random;
 
@@ -19,10 +20,6 @@ import java.util.Random;
 public class TokenProvider {
     @Value("${jwt.secret}")
     String secret;
-    @Value("${jwt.token-validity-in-seconds}")
-    long tokenValidityInMilliseconds;
-    @Value("${jwt.refresh-token.expire-length}")
-    long refreshTokenValidityInMilliseconds;
 
     private String generate(String payload, long tokenValidity) {
         Claims claims = Jwts.claims().setSubject(payload);
@@ -38,14 +35,14 @@ public class TokenProvider {
     }
 
     public String generateAccessToken(String payload) {
-        return generate(payload, tokenValidityInMilliseconds);
+        return generate(payload, Duration.ofMinutes(30).toMillis());
     }
 
     public String generateRefreshToken() {
         byte[] array = new byte[7];
         new Random().nextBytes(array);
         String generatedString = new String(array, StandardCharsets.UTF_8);
-        return generate(generatedString, refreshTokenValidityInMilliseconds);
+        return generate(generatedString, Duration.ofDays(14).toMillis());
     }
 
     public void validateToken(String token) {

--- a/member_service/src/main/java/com/luckytree/member_service/member/adapter/web/AuthController.java
+++ b/member_service/src/main/java/com/luckytree/member_service/member/adapter/web/AuthController.java
@@ -49,7 +49,7 @@ public class AuthController {
     }
 
     @PostMapping("/token")
-    public ResponseEntity reissueToken(@RequestHeader("refresh-token") String refreshToken) {
+    public ResponseEntity reissueToken(@CookieValue("refresh-token") String refreshToken) {
         Tokens tokens = authenticationUseCase.reissue(refreshToken);
         String refreshTokenCookie = authenticationUseCase.makeCookie(tokens.getRefreshToken());
 


### PR DESCRIPTION
# 작업내용
* 헤더가 아닌 쿠키 밸류를 통해 리프레시 토큰을 받는다.
* 토큰 만료시간을 코드 형태로 수정한다.